### PR TITLE
Added demanded dependency version checking

### DIFF
--- a/content/ucp/main.lua
+++ b/content/ucp/main.lua
@@ -99,10 +99,6 @@ if config.active == false then
     return nil
 end
 
----Overwrite game menu version and store game version details
-data.version.initialize(config)
-
-
 extensionsTable = {}
 extensionLoaders = {}
 
@@ -174,10 +170,14 @@ explicitlyActiveExtensions = {}
 for k, ext in pairs(extensionLoadOrder) do
     if joinedConfig.extensions[ext] then
         if joinedConfig.extensions[ext].active == true then
-            table.insert(explicitlyActiveExtensions, ext)
+            if data.version.verifyDependencies(ext, extensionLoaders) then
+				table.insert(explicitlyActiveExtensions, ext)
+			end
         end
     elseif joinedDefaultConfig.extensions[ext] and joinedDefaultConfig.extensions[ext].active == true then
-        table.insert(explicitlyActiveExtensions, ext)
+        if data.version.verifyDependencies(ext, extensionLoaders) then
+            table.insert(explicitlyActiveExtensions, ext)
+        end
     end
 end
 
@@ -260,6 +260,8 @@ end
 mergeConfiguration(default_config, configMaster)
 configFinal = default_config
 
+---Overwrite game menu version and store game version details
+data.version.initialize(configFinal)
 
 ---Table to hold all the modules
 ---@type table<string, Module>


### PR DESCRIPTION
Modules can now demand for version restrictions on their dependencies inside their definition.yml.
![versions1](https://user-images.githubusercontent.com/50240040/135157700-eedc0b68-baf9-4c46-91ef-9df4deff70cf.png)
Supported operators: `==, <=, >=, <, >`

Additionally moved `data.version.initialize(configFinal)` down a bit inside main.lua to ensure it uses the merged configFinal.